### PR TITLE
Show round of 16 in results page, finals group

### DIFF
--- a/static/js/views/bracket-display.js
+++ b/static/js/views/bracket-display.js
@@ -276,7 +276,7 @@ export default Route(SINGLETON_NAME,{
 
     if (group === 'finals') {
       group = null;
-      tier = bracketData.results.length - 3;
+      tier = Math.max(0, bracketData.results.length - 4);
     } else if (group === 'full') {
       group = null;
       tier = 0;


### PR DESCRIPTION
When `Finals` is selected on results page, show Round of 16 (used to be from Quarterfinals to Final)
<img width="2557" height="1235" alt="image" src="https://github.com/user-attachments/assets/0423c3a7-2538-4c7f-b691-d3945b7fc390" />
