### PR TITLE
Allow post-submission vote switching and remove View Results link during elims

### DIFF
--- a/api/votes.php
+++ b/api/votes.php
@@ -3,33 +3,51 @@
 namespace Api {
     
     use Lib;
+    use stdClass;
 
     class Votes {
 
         /**
-         * Takes a list of rounds and returns rounds with open voting
-         * that the user has not yet voted on
+         * Returns non-deleted rounds in the bracket keyed by round id.
+         * Each entry has character1Id, character2Id, and final.
+         *
+         * @return array<int, stdClass>
          */
-        public static function getOpenRounds($user, $votes) {
-            
-            $params = [ ':userId' => $user->id ];
+        public static function getValidRoundEntrants($votes, $bracketId) {
+            $retVal = [];
+            $params = self::_roundParams($votes);
+            if (!$params) {
+                return $retVal;
+            }
+
+            $params[':bracketId'] = $bracketId;
+            $roundKeys = implode(',', array_keys(array_diff_key($params, [ ':bracketId' => true ])));
+            $query = 'SELECT round_id, round_character1_id, round_character2_id, round_final'
+                . ' FROM round'
+                . ' WHERE bracket_id = :bracketId AND round_deleted = 0 AND round_id IN (' . $roundKeys . ')';
+            $result = Lib\Db::Query($query, $params);
+            if ($result && $result->count > 0) {
+                while ($row = Lib\Db::Fetch($result)) {
+                    $round = new stdClass;
+                    $round->character1Id = (int) $row->round_character1_id;
+                    $round->character2Id = (int) $row->round_character2_id;
+                    $round->final = (int) $row->round_final === 1;
+                    $retVal[(int) $row->round_id] = $round;
+                }
+            }
+
+            return $retVal;
+        }
+
+        /**
+         * @return array<string, int>
+         */
+        private static function _roundParams($votes) {
+            $params = [];
             for ($i = 0, $count = count($votes); $i < $count; $i++) {
                 $params[':round' . $i] = $votes[$i]->roundId;
             }
-            
-            $roundKeys = implode(',', array_keys($params));
-            $query = 'SELECT round_id FROM votes WHERE user_id = :userId AND round_id IN (' . $roundKeys . ') UNION ';
-            $query .= 'SELECT round_id FROM round WHERE round_id IN (' . $roundKeys . ') AND round_final = 1';
-
-            $result = Lib\Db::Query($query, $params);
-            $retVal = [];
-            if ($result && $result->count > 0) {
-                while ($row = Lib\Db::Fetch($result)) {
-                    $retVal[$row->round_id] = true;
-                }
-            }
-            
-            return $retVal;
+            return $params;
         }
 
     }

--- a/controller/submit.php
+++ b/controller/submit.php
@@ -149,58 +149,83 @@ namespace Controller {
                 $count = count($votes);
                 if ($count > 0) {
 
-                    $query = 'INSERT INTO `votes` (`user_id`, `vote_date`, `round_id`, `character_id`, `bracket_id`) VALUES ';
-                    $params = [ ':userId' => $user->id, ':date' => time(), ':bracketId' => $bracketId ];
-
-                    $insertCount = 0;
-
-                    // Only run an insert for rounds that haven't been voted on
-                    $rounds = Api\Votes::getOpenRounds($user, $votes);
+                    $validRounds = Api\Votes::getValidRoundEntrants($votes, $bracketId);
+                    $writeVotes = [];
 
                     for ($i = 0; $i < $count; $i++) {
-                        if (!isset($rounds[$votes[$i]->roundId])) {
-                            $query .= '(:userId, :date, :round' . $i . ', :character' . $i . ', :bracketId),';
-                            $params[':round' . $i] = $votes[$i]->roundId;
-                            $params[':character' . $i] = $votes[$i]->characterId;
-                            $insertCount++;
-                            $rounds[$votes[$i]->roundId] = true;
+                        $roundId = $votes[$i]->roundId;
+                        $characterId = $votes[$i]->characterId;
+
+                        if (!isset($validRounds[$roundId])) {
+                            continue;
                         }
+
+                        $roundInfo = $validRounds[$roundId];
+                        if ($roundInfo->final) {
+                            continue;
+                        }
+
+                        if ($characterId !== $roundInfo->character1Id && $characterId !== $roundInfo->character2Id) {
+                            continue;
+                        }
+
+                        $writeVotes[] = $votes[$i];
                     }
 
-                    if ($insertCount > 0) {
+                    if (count($writeVotes) === 0) {
+                        $out->message = 'Voting for this round has closed';
+                        $out->code = 'closed';
+                    } else {
+                        $query = 'INSERT INTO `votes` (`user_id`, `vote_date`, `round_id`, `character_id`, `bracket_id`) VALUES ';
+                        $params = [];
+                        $voteDate = time();
+                        for ($i = 0, $writeCount = count($writeVotes); $i < $writeCount; $i++) {
+                            $query .= '(:user' . $i . ', :date' . $i . ', :round' . $i . ', :character' . $i . ', :bracket' . $i . '),';
+                            $params[':user' . $i] = $user->id;
+                            $params[':date' . $i] = $voteDate;
+                            $params[':round' . $i] = $writeVotes[$i]->roundId;
+                            $params[':character' . $i] = $writeVotes[$i]->characterId;
+                            $params[':bracket' . $i] = $bracketId;
+                        }
                         $query = substr($query, 0, strlen($query) - 1);
-                        if (Lib\Db::Query($query, $params)) {
+                        $query .= ' ON DUPLICATE KEY UPDATE'
+                            . ' `character_id` = VALUES(`character_id`),'
+                            . ' `vote_date` = VALUES(`vote_date`)';
+
+                        if (!Lib\Db::Query($query, $params)) {
+                            $out->message = 'There was an unexpected error. Please try again in a few moments.';
+                        } else {
                             $out->success = true;
 
-                            // Clear any user related caches
-                            $round = Api\Round::getById($votes[0]->roundId);
+                            // Clear any user related caches using a validated open round from this ballot
+                            $round = Api\Round::getById($writeVotes[0]->roundId);
                             $cache = Lib\Cache::getInstance();
                             $cache->set('GetBracketRounds_' . $bracketId . '_' . $round->tier . '_' . $round->group . '_' . $user->id, false);
                             $cache->set('GetBracketRounds_' . $bracketId . '_' . $round->tier . '_all_' . $user->id, false);
                             $cache->set('CurrentRound_' . $bracketId . '_' . $user->id, false);
                             $bracket->getVotesForUser($user, true);
 
-                            // Link to the group that was just voted (Finals = last 4 tiers, same as results UI)
-                            $results = $bracket->getResults();
-                            $tierCount = is_array($results) ? count($results) : 0;
-                            $resultsGroup = ($tierCount > 0 && ((int) $round->tier - 1) >= $tierCount - 4)
-                                ? 'finals'
-                                : ((int) $round->group + 1);
+                            $out->message = 'Your votes were successfully submitted!';
 
-                            // I am vehemently against putting markup in the controller, but there's much refactor needed to make this right
-                            // So, that's a note that it will be changed in the future
-                            $out->message = 'Your votes were successfully submitted! <a href="/' . $bracket->perma . '/results?group=' . $resultsGroup . '">View Results</a>';
+                            // View Results only during bracket voting — elim tallies are not public
+                            if ($bracket->state === BS_VOTING) {
+                                $results = $bracket->getResults();
+                                $tierCount = is_array($results) ? count($results) : 0;
+                                $resultsGroup = ($tierCount > 0 && ((int) $round->tier - 1) >= $tierCount - 4)
+                                    ? 'finals'
+                                    : ((int) $round->group + 1);
+
+                                // I am vehemently against putting markup in the controller, but there's much refactor needed to make this right
+                                // So, that's a note that it will be changed in the future
+                                $out->message .= ' <a href="/' . $bracket->perma . '/results?group=' . $resultsGroup . '">View Results</a>';
+                            }
+
                             // Oops, I did it again...
                             if ($bracket->externalId) {
-                                $out->message .=  ' or <a href="http://redd.it/' . $bracket->externalId . '" target="_blank">discuss on reddit</a>.';
+                                $prefix = $bracket->state === BS_VOTING ? ' or ' : ' ';
+                                $out->message .= $prefix . '<a href="http://redd.it/' . $bracket->externalId . '" target="_blank">discuss on reddit</a>.';
                             }
-                        } else {
-                            $out->message = 'There was an unexpected error. Please try again in a few moments.';
                         }
-
-                    } else {
-                        $out->message = 'Voting for this round has closed';
-                        $out->code = 'closed';
                     }
 
                 } else {

--- a/static/js/pages/Vote/useVoteForm.js
+++ b/static/js/pages/Vote/useVoteForm.js
@@ -25,25 +25,31 @@ export const useVoteForm = ({ rounds, bracket }) => {
 
   const selectEntrant = ({ roundId, entrantId }) => {
     const { character1, character2, ...roundProps } = ballot[roundId];
+    const clickingSelected =
+      (character1.selected && character1.id === entrantId) ||
+      (character2.selected && character2.id === entrantId);
 
-
-    // if the user has already cast a vote in this round, nope
-    if (roundProps.voted) {
+    // Saved votes cannot be cleared — clicking the current pick is a no-op
+    if (roundProps.voted && clickingSelected) {
       return;
     }
 
+    // Saved: select clicked entrant. Unsaved: toggle (click again to clear).
+    const selectClicked = (character) => (
+      roundProps.voted
+        ? character.id === entrantId
+        : character.id === entrantId && !character.selected
+    );
+
     const updatedRound = {
       ...roundProps,
-      // update the selected state of each character such that:
-      // - it was the character marked as selected
-      // - that character wasn't _already_ selected. if they are, unselect
       character1: {
         ...character1,
-        selected: character1.id === entrantId && !character1.selected,
+        selected: selectClicked(character1),
       },
       character2: {
         ...character2,
-        selected: character2.id === entrantId && !character2.selected,
+        selected: selectClicked(character2),
       },
     };
 
@@ -58,10 +64,20 @@ export const useVoteForm = ({ rounds, bracket }) => {
 
     Object.keys(ballot).forEach(roundId => {
       const round = ballot[roundId];
-      if (!round.character1.voted && round.character1.selected) {
-        formData.append(`round:${roundId}`, round.character1.id);
-      } else if (!round.character2.voted && round.character2.selected) {
-        formData.append(`round:${roundId}`, round.character2.id);
+      const selectedId = round.character1.selected
+        ? round.character1.id
+        : (round.character2.selected ? round.character2.id : null);
+      if (selectedId == null) {
+        return;
+      }
+
+      const votedId = round.character1.voted
+        ? round.character1.id
+        : (round.character2.voted ? round.character2.id : null);
+
+      // New votes and changed votes; skip unchanged already-voted picks
+      if (votedId !== selectedId) {
+        formData.append(`round:${roundId}`, selectedId);
       }
     });
 
@@ -82,7 +98,7 @@ export const useVoteForm = ({ rounds, bracket }) => {
       setBallot(Object.keys(ballot).reduce((acc, roundId) => {
         const { character1, character2, ...roundProps } = ballot[roundId];
         acc[roundId] = {
-          roundProps,
+          ...roundProps,
           voted: character1.selected || character2.selected,
           character1: {
             ...character1,
@@ -91,7 +107,7 @@ export const useVoteForm = ({ rounds, bracket }) => {
           character2: {
             ...character2,
             voted: character2.selected,
-          }
+          },
         };
         return acc;
       }, {}));


### PR DESCRIPTION
DO NOT MERGE YET

https://github.com/Syrefva/animebracket/pull/17 (was reverted in https://github.com/Syrefva/animebracket/pull/18 and restored in https://github.com/Syrefva/animebracket/pull/19)

- removed "View Results" link during elims since the page isn't accessible yet
- allow users to change their vote after submission. Does not allow canceling a vote (for elims, this means vote can't be removed once submitted. for voting phase, this means you can only change selection to the other entrant; you can't change to voting for neither)