### PR TITLE
Purge Votes Script

### DIFF
--- a/.cursor/plans/purge_user_votes_script_a3804013.plan.md
+++ b/.cursor/plans/purge_user_votes_script_a3804013.plan.md
@@ -1,0 +1,124 @@
+---
+name: Purge User Votes Script
+overview: Add a CLI script that deletes listed users’ tournament votes in one bracket, recounts finalized tallies, and cascades corrected winners into later rounds only when the displaced character has no votes yet in that next round—otherwise leave advancement as-is so the contest can continue.
+todos:
+  - id: add-script
+    content: Add scripts/purge-bracket-votes.php with CLI args, dry-run default, --apply
+    status: completed
+  - id: delete-and-guards
+    content: Resolve bracket/users; require BS_VOTING; delete only tier>=1 votes for user_id list
+    status: completed
+  - id: cascade-repair
+    content: "Conditional cascade: replace next-round entrant only if that character has 0 votes there"
+    status: completed
+  - id: recount-caches
+    content: Recount finalized tallies and invalidate bracket/user/stats caches
+    status: completed
+isProject: false
+---
+
+# Purge Bracket Votes (Conditional Cascade)
+
+## Why not rollback + re-advance
+
+Existing [`proc_RollbackBracket`](sql/proc_RollbackBracket.sql) / [`Bracket::rollback()`](api/bracket.php) is the wrong tool here:
+
+1. After un-finalizing rounds, it **deletes all votes** on those rounds (everyone’s), including the votes needed to re-decide winners.
+2. Calling [`advance()`](api/bracket.php) again would recreate later tiers and finalize them from **empty** intermediate rounds (seed tiebreak), destroying legitimate voting history.
+
+## Approach
+
+New CLI script: [`scripts/purge-bracket-votes.php`](scripts/purge-bracket-votes.php) (bootstrap like [`cron/advance.php`](cron/advance.php): `config.php` + `app-config.php` + `lib/aal.php`).
+
+**Invocation (dry-run by default):**
+
+```bash
+php scripts/purge-bracket-votes.php --bracket=<id|perma> --users=12,34,56
+php scripts/purge-bracket-votes.php --bracket=<id|perma> --users=12,34,56 --apply
+```
+
+Users are numeric `user_id` only.
+
+```mermaid
+flowchart TD
+  deleteVotes[Delete listed users tournament votes]
+  walkTree[Walk feeders earliest to latest]
+  checkNext{"Displaced character has 0 votes in next round?"}
+  cascade[Replace slot with correct winner]
+  accept[Leave next-round entrant as-is]
+  recount[Recount finalized round_character votes]
+  caches[Invalidate bracket caches]
+  deleteVotes --> walkTree --> checkNext
+  checkNext -->|yes| cascade --> recount
+  checkNext -->|no| accept --> recount
+  recount --> caches
+```
+
+### Steps
+
+1. **Resolve bracket** by numeric id or perma; require `BS_VOTING` only (not eliminations, not final).
+2. **Resolve users** by `user_id`; fail if any id is missing.
+3. **Report** (always): tournament vote counts per user, per tier/group, finalized vs open. Mention any tier-0 votes found for these users but leave them untouched.
+4. **Delete** only tournament votes via join:
+
+```sql
+DELETE v FROM votes v
+INNER JOIN round r ON r.round_id = v.round_id
+WHERE v.bracket_id = :bracketId
+  AND v.user_id IN (...)
+  AND r.round_tier >= 1
+```
+
+Elimination (`round_tier = 0`) votes are never read for repair logic and never deleted.
+
+5. **Conditional cascade** for tournament rounds (`round_tier >= 1`, `round_deleted = 0`), earliest tier → latest:
+   - Mirror advance pairing from [`_advanceBracket`](api/bracket.php): consecutive rounds in a completed tier/group feed the next tier (`order = i/2`, `character1` = winner of round `i`, `character2` = winner of round `i+1`; third-place match gets the two losers when present).
+   - Recompute each feeder’s winner via `Round::getWinnerId()` / `getLoserId()` (live remaining `votes` + seed tiebreak in [`proc_GetRoundWinner`](sql/proc_GetRoundWinner.sql)).
+   - If the next round already has the correct character in that slot → nothing to do.
+   - If the next round has the **wrong** character (e.g. Char D) in that slot:
+     - Count Char D’s votes in that next round **after** step 4’s purge delete (so ballots from the purged users are already gone). A round that has not opened for voting yet (or has opened but received no ballots for Char D) counts as zero.
+     - **Cascade** only when that post-delete count is **zero**: update the slot to the correct winner; nothing left to strip for the removed character (opponent votes, if any, stay).
+     - **Otherwise accept history**: leave the next-round entrant unchanged even if the feeder recount says they should have lost. Contest continues; feeder tallies after recount may disagree with who advanced (dry-run must call this out).
+   - Walk forward so a cascade into an empty later round can itself cascade further under the same rule.
+
+6. **Recount denormalized tallies** on every finalized tournament round (always, including accepted historical mismatches): set `round_character1_votes` / `round_character2_votes` from `COUNT` of remaining votes (same logic as [`Round::getVoteCount()`](api/round.php) + [`finalizeRound()`](api/round.php)). Leave non-finalized rounds’ stored counts `NULL`.
+
+7. **Cache bust**:
+   - Long-lived Redis: `Api:Bracket:getResults_{id}`, `Api:Round:getVotingStates_{id}` (admin vote chart), `Api:Bracket:getVotesForUser_{id}_{userId}` for purged users; force-refresh `Stats::getEntrantPerformanceStats($bracket, true)`.
+   - Memcache `GetBracketRounds_*` is per-user with medium TTL; after a cascade on an open round, ballots may briefly show old entrants until expiry (same general pattern as normal advance). No other durable cache of vote tallies.
+
+Dry-run prints the full plan (rows to delete, cascades vs accepted mismatches, recount diffs) and makes **no writes**.
+
+## Related data audit
+
+Durable DB state that vote purge can affect:
+
+| Store | Action |
+|-------|--------|
+| `votes` | Delete purged users’ `tier >= 1` rows |
+| `round.character1/2` | Conditional cascade only |
+| `round.character1/2_votes` | Always recount when `final` |
+| `character.seed`, nominees, elim votes | Untouched (out of scope) |
+| `bracket.winner` / `BS_FINAL` | N/A (script refuses finals) |
+| `bracket.score` | Untouched (cron owns this) |
+
+Everything else (open-round live counts, affinity/`ai_projections`, CSV download, “have I voted”) reads `votes` directly or short caches. Accepted historical mismatches (feeder recount vs who advanced when cascade is blocked) can make results/stats *look* inconsistent; that is intentional, not a missed write.
+
+## What “correct end state” means
+
+| Data | After script |
+|------|----------------|
+| Purged users’ tournament votes (`tier >= 1`) | Gone |
+| Elimination votes (`tier = 0`) | Untouched |
+| Finalized tournament `round_character*_votes` | Recounted from remaining votes |
+| Next-round slot when displaced character has 0 votes there (after purge) | Corrected to true winner |
+| Next-round slot when displaced character still has votes after purge | Left as-is (accept advancement) |
+| Contest continuation | Unaffected |
+
+## Out of scope
+
+- Admin UI
+- Eliminations votes, eliminations state, or rebuilding seeding from elims
+- Finalized (`BS_FINAL`) brackets
+- Identifying users by Reddit name
+- Forcing bracket structure to match recount when later rounds already have votes for the displaced character

--- a/scripts/purge-bracket-votes.php
+++ b/scripts/purge-bracket-votes.php
@@ -1,0 +1,617 @@
+<?php
+
+/**
+ * Purge tournament votes for a list of users in one bracket, recount finalized
+ * tallies, and conditionally cascade corrected winners into later rounds when
+ * the displaced character has zero votes there (after the purge).
+ *
+ * Dry-run by default. Pass --apply to write.
+ *
+ * Usage:
+ *   php scripts/purge-bracket-votes.php --bracket=<id|perma> --users=12,34,56
+ *   php scripts/purge-bracket-votes.php --bracket=<id|perma> --users=12,34,56 --apply
+ *
+ * From the compose web container (DB_HOST=db required for CLI):
+ *   docker compose exec -e DB_HOST=db web php scripts/purge-bracket-votes.php --bracket=<id|perma> --users=12,34,56
+ */
+
+require_once __DIR__ . '/../app-config.php';
+chdir(CORE_LOCATION);
+require_once 'config.php';
+require_once './lib/aal.php';
+
+Lib\Cache::getInstance()->setDisabled(true);
+
+$options = getopt('', [ 'bracket:', 'users:', 'apply' ]);
+$apply = array_key_exists('apply', $options);
+
+if (empty($options['bracket']) || empty($options['users'])) {
+    fwrite(STDERR, "Usage: php scripts/purge-bracket-votes.php --bracket=<id|perma> --users=12,34,56 [--apply]\n");
+    exit(1);
+}
+
+$userIds = array_values(array_unique(array_filter(array_map('intval', explode(',', $options['users'])))));
+if (count($userIds) === 0) {
+    fwrite(STDERR, "Error: --users must be a comma-separated list of numeric user_id values.\n");
+    exit(1);
+}
+
+$bracket = resolveBracket($options['bracket']);
+if (!$bracket) {
+    fwrite(STDERR, "Error: bracket not found for " . $options['bracket'] . "\n");
+    exit(1);
+}
+
+if ((int) $bracket->state !== BS_VOTING) {
+    fwrite(STDERR, "Error: bracket must be in voting state (BS_VOTING). Current state=" . $bracket->state . "\n");
+    exit(1);
+}
+
+$users = resolveUsers($userIds);
+if ($users === null) {
+    exit(1);
+}
+
+echo $apply ? "MODE: APPLY\n" : "MODE: DRY-RUN (pass --apply to write)\n";
+echo "Bracket: {$bracket->name} (id={$bracket->id}, perma={$bracket->perma})\n";
+echo 'Users: ' . implode(', ', array_map(function ($user) {
+    return $user->id . ' (/u/' . $user->name . ')';
+}, $users)) . "\n\n";
+
+$report = reportVotes($bracket->id, $userIds);
+printVoteReport($report);
+
+$userPlaceholders = buildInPlaceholders($userIds, 'user');
+$userParams = buildInParams($userIds, 'user');
+
+$deleteSql = 'DELETE v FROM votes v'
+    . ' INNER JOIN round r ON r.round_id = v.round_id'
+    . ' WHERE v.bracket_id = :bracketId'
+    . ' AND v.user_id IN (' . $userPlaceholders . ')'
+    . ' AND r.round_tier >= 1';
+
+$deleteCountSql = 'SELECT COUNT(1) AS total FROM votes v'
+    . ' INNER JOIN round r ON r.round_id = v.round_id'
+    . ' WHERE v.bracket_id = :bracketId'
+    . ' AND v.user_id IN (' . $userPlaceholders . ')'
+    . ' AND r.round_tier >= 1';
+
+$deleteParams = array_merge([ ':bracketId' => $bracket->id ], $userParams);
+$pendingDelete = (int) fetchScalar($deleteCountSql, $deleteParams);
+echo "Tournament votes to delete: {$pendingDelete}\n\n";
+
+// Cascades and recounts use post-purge vote tallies. In dry-run, exclude these users.
+$excludeUserIds = $apply ? [] : $userIds;
+
+if ($apply) {
+    $deleted = Lib\Db::Query($deleteSql, $deleteParams);
+    if ($deleted === false) {
+        fwrite(STDERR, "Error: failed to delete votes.\n");
+        exit(1);
+    }
+    echo "Deleted vote rows: {$deleted}\n\n";
+    $excludeUserIds = [];
+}
+
+$rounds = loadTournamentRounds($bracket->id);
+$slotMap = [];
+foreach ($rounds as $round) {
+    $slotMap[(int) $round->id] = [
+        (int) $round->character1Id,
+        (int) $round->character2Id,
+    ];
+}
+
+$cascadeActions = planCascades($rounds, $slotMap, $excludeUserIds);
+printCascadeReport($cascadeActions);
+
+if ($apply) {
+    foreach ($cascadeActions as $action) {
+        if ($action['type'] !== 'cascade') {
+            continue;
+        }
+        $round = $rounds[$action['nextRoundId']];
+        if ($action['slot'] === 1) {
+            $round->character1Id = $action['expectedCharacterId'];
+        } else {
+            $round->character2Id = $action['expectedCharacterId'];
+        }
+        $round->sync();
+        echo "Cascaded round {$round->id}: entrant {$action['slot']} "
+            . formatEntrantLabel($action['actualCharacterId'])
+            . ' -> '
+            . formatEntrantLabel($action['expectedCharacterId'])
+            . "\n";
+    }
+    if (count(array_filter($cascadeActions, function ($action) {
+        return $action['type'] === 'cascade';
+    })) > 0) {
+        echo "\n";
+    }
+}
+
+$recountActions = planRecounts($rounds, $slotMap, $excludeUserIds);
+printRecountReport($recountActions);
+printOpenRoundsReport($rounds, $slotMap);
+
+if ($apply) {
+    foreach ($recountActions as $action) {
+        $round = $rounds[$action['roundId']];
+        $round->character1Id = $slotMap[(int) $round->id][0];
+        $round->character2Id = $slotMap[(int) $round->id][1];
+        $round->character1Votes = $action['character1Votes'];
+        $round->character2Votes = $action['character2Votes'];
+        $round->sync();
+    }
+    echo 'Updated finalized tallies on ' . count($recountActions) . " round(s).\n\n";
+    bustCaches($bracket, $users);
+    echo "Cache refresh complete.\n";
+    echo "Done.\n";
+} else {
+    echo "Dry-run complete. Re-run with --apply to write changes.\n";
+}
+
+/**
+ * @param string|int $bracketArg
+ * @return Api\Bracket|null
+ */
+function resolveBracket($bracketArg) {
+    if (is_numeric($bracketArg)) {
+        $bracket = Api\Bracket::getById((int) $bracketArg);
+        if ($bracket && (int) $bracket->id > 0) {
+            return $bracket;
+        }
+    }
+    return Api\Bracket::getBracketByPerma((string) $bracketArg, true) ?: null;
+}
+
+/**
+ * @param int[] $userIds
+ * @return Api\User[]|null
+ */
+function resolveUsers(array $userIds) {
+    $users = [];
+    foreach ($userIds as $userId) {
+        $user = Api\User::getById($userId);
+        if (!$user || !(int) $user->id) {
+            fwrite(STDERR, "Error: user_id {$userId} not found.\n");
+            return null;
+        }
+        $users[] = $user;
+    }
+    return $users;
+}
+
+/**
+ * @param int $bracketId
+ * @param int[] $userIds
+ * @return object
+ */
+function reportVotes($bracketId, array $userIds) {
+    $placeholders = buildInPlaceholders($userIds, 'user');
+    $params = array_merge([ ':bracketId' => $bracketId ], buildInParams($userIds, 'user'));
+
+    $sql = 'SELECT'
+        . ' SUM(CASE WHEN r.round_tier = 0 THEN 1 ELSE 0 END) AS elim_total,'
+        . ' SUM(CASE WHEN r.round_tier >= 1 THEN 1 ELSE 0 END) AS tournament_total'
+        . ' FROM votes v'
+        . ' INNER JOIN round r ON r.round_id = v.round_id'
+        . ' WHERE v.bracket_id = :bracketId'
+        . ' AND v.user_id IN (' . $placeholders . ')';
+
+    $row = null;
+    $result = Lib\Db::Query($sql, $params);
+    if ($result && $result->count) {
+        $row = Lib\Db::Fetch($result);
+    }
+
+    return (object) [
+        'elimTotal' => (int) ($row->elim_total ?? 0),
+        'tournamentTotal' => (int) ($row->tournament_total ?? 0),
+    ];
+}
+
+/**
+ * @param object $report
+ */
+function printVoteReport($report) {
+    if ($report->elimTotal > 0) {
+        echo "Note: listed users also have {$report->elimTotal} elimination vote(s); those are left untouched.\n\n";
+    }
+}
+
+/**
+ * @param int $bracketId
+ * @return array<int, Api\Round> keyed by round id
+ */
+function loadTournamentRounds($bracketId) {
+    $rounds = Api\Round::queryReturnAll([
+        'bracketId' => $bracketId,
+        'tier' => [ 'gt' => 0 ],
+        'deleted' => 0,
+    ], [
+        'tier' => 'asc',
+        'group' => 'asc',
+        'order' => 'asc',
+    ]) ?: [];
+
+    $byId = [];
+    foreach ($rounds as $round) {
+        $byId[(int) $round->id] = $round;
+    }
+    return $byId;
+}
+
+/**
+ * @param array<int, Api\Round> $rounds
+ * @param array<int, array{0:int,1:int}> $slotMap
+ * @param int[] $excludeUserIds
+ * @return array<int, array>
+ */
+function planCascades(array $rounds, array &$slotMap, array $excludeUserIds) {
+    $actions = [];
+    $roundsByTier = [];
+    foreach ($rounds as $round) {
+        if (!empty($round->isThirdPlaceMatch)) {
+            continue;
+        }
+        $tier = (int) $round->tier;
+        if (!isset($roundsByTier[$tier])) {
+            $roundsByTier[$tier] = [];
+        }
+        $roundsByTier[$tier][] = $round;
+    }
+
+    $tiers = array_keys($roundsByTier);
+    sort($tiers, SORT_NUMERIC);
+
+    foreach ($tiers as $tier) {
+        foreach ($roundsByTier[$tier] as $feeder) {
+            if ((int) $feeder->final !== 1) {
+                continue;
+            }
+
+            $slots = $slotMap[(int) $feeder->id];
+            $expectedWinner = computeWinnerId(
+                $feeder->id,
+                $slots[0],
+                $slots[1],
+                $excludeUserIds
+            );
+            $expectedLoser = computeLoserId($slots[0], $slots[1], $expectedWinner);
+            if (!$expectedWinner) {
+                continue;
+            }
+
+            $nextTier = $tier + 1;
+
+            foreach ($rounds as $nextRound) {
+                if ((int) $nextRound->tier !== $nextTier) {
+                    continue;
+                }
+
+                $nextSlots = $slotMap[(int) $nextRound->id];
+                $feederCharacterIds = array_values(array_filter($slots, function ($characterId) {
+                    return (int) $characterId > 1;
+                }));
+
+                foreach ([ 1 => $nextSlots[0], 2 => $nextSlots[1] ] as $slotNumber => $actualCharacterId) {
+                    if (!in_array((int) $actualCharacterId, $feederCharacterIds, true)) {
+                        continue;
+                    }
+
+                    $isThird = !empty($nextRound->isThirdPlaceMatch);
+                    $expectedCharacterId = $isThird ? $expectedLoser : $expectedWinner;
+                    if (!$expectedCharacterId) {
+                        continue;
+                    }
+
+                    if ((int) $actualCharacterId === (int) $expectedCharacterId) {
+                        continue;
+                    }
+
+                    $votesForActual = countCharacterVotes(
+                        (int) $nextRound->id,
+                        (int) $actualCharacterId,
+                        $excludeUserIds
+                    );
+
+                    $action = [
+                        'type' => $votesForActual === 0 ? 'cascade' : 'accept',
+                        'feederRoundId' => (int) $feeder->id,
+                        'feederTier' => (int) $feeder->tier,
+                        'nextRoundId' => (int) $nextRound->id,
+                        'nextTier' => (int) $nextRound->tier,
+                        'slot' => $slotNumber,
+                        'actualCharacterId' => (int) $actualCharacterId,
+                        'expectedCharacterId' => (int) $expectedCharacterId,
+                        'votesForActual' => $votesForActual,
+                        'isThirdPlaceMatch' => $isThird,
+                    ];
+                    $actions[] = $action;
+
+                    if ($action['type'] === 'cascade') {
+                        $slotMap[(int) $nextRound->id][$slotNumber - 1] = (int) $expectedCharacterId;
+                    }
+                }
+            }
+        }
+    }
+
+    return $actions;
+}
+
+/**
+ * @param array $actions
+ */
+function printCascadeReport(array $actions) {
+    echo "Cascade plan:\n";
+    if (count($actions) === 0) {
+        echo "  (no mismatches between feeder winners and later-round entrants)\n\n";
+        return;
+    }
+
+    foreach ($actions as $action) {
+        $label = $action['type'] === 'cascade' ? 'CASCADE' : 'NO CASCADE';
+        $third = $action['isThirdPlaceMatch'] ? ' [third-place]' : '';
+        $line = "  {$label}: feeder round {$action['feederRoundId']}"
+            . " (tier {$action['feederTier']})"
+            . " -> next round {$action['nextRoundId']}"
+            . " (tier {$action['nextTier']}){$third}"
+            . " entrant {$action['slot']}:"
+            . ' ' . formatEntrantLabel($action['actualCharacterId']);
+        if ($action['type'] === 'cascade') {
+            $line .= ' => ' . formatEntrantLabel($action['expectedCharacterId']);
+        }
+        echo $line . "\n";
+    }
+    echo "\n";
+}
+
+/**
+ * @param array<int, Api\Round> $rounds
+ * @param array<int, array{0:int,1:int}> $slotMap
+ * @param int[] $excludeUserIds
+ * @return array<int, array>
+ */
+function planRecounts(array $rounds, array $slotMap, array $excludeUserIds) {
+    $actions = [];
+    foreach ($rounds as $round) {
+        if ((int) $round->final !== 1) {
+            continue;
+        }
+        $slots = $slotMap[(int) $round->id];
+        $character1Votes = countCharacterVotes((int) $round->id, $slots[0], $excludeUserIds);
+        $character2Votes = countCharacterVotes((int) $round->id, $slots[1], $excludeUserIds);
+        $actions[] = [
+            'roundId' => (int) $round->id,
+            'tier' => (int) $round->tier,
+            'character1Id' => $slots[0],
+            'character2Id' => $slots[1],
+            'character1Votes' => $character1Votes,
+            'character2Votes' => $character2Votes,
+            'previousCharacter1Votes' => $round->character1Votes,
+            'previousCharacter2Votes' => $round->character2Votes,
+        ];
+    }
+    return $actions;
+}
+
+/**
+ * @param array $actions
+ */
+function printRecountReport(array $actions) {
+    echo "Finalized tally recount:\n";
+    if (count($actions) === 0) {
+        echo "  (no finalized tournament rounds)\n\n";
+        return;
+    }
+    foreach ($actions as $action) {
+        $changed = ((int) $action['previousCharacter1Votes'] !== (int) $action['character1Votes'])
+            || ((int) $action['previousCharacter2Votes'] !== (int) $action['character2Votes']);
+        $flag = $changed ? ' *' : '';
+        echo "  round {$action['roundId']} (tier {$action['tier']}):"
+            . ' ' . formatEntrantLabel($action['character1Id'])
+            . " {$action['previousCharacter1Votes']}->{$action['character1Votes']},"
+            . ' ' . formatEntrantLabel($action['character2Id'])
+            . " {$action['previousCharacter2Votes']}->{$action['character2Votes']}"
+            . "{$flag}\n";
+    }
+    echo "\n";
+}
+
+/**
+ * @param array<int, Api\Round> $rounds
+ * @param array<int, array{0:int,1:int}> $slotMap
+ */
+function printOpenRoundsReport(array $rounds, array $slotMap) {
+    echo "Open (non-finalized) matchups:\n";
+    $any = false;
+    foreach ($rounds as $round) {
+        if ((int) $round->final === 1) {
+            continue;
+        }
+        $any = true;
+        $slots = $slotMap[(int) $round->id];
+        $changed = ((int) $slots[0] !== (int) $round->character1Id)
+            || ((int) $slots[1] !== (int) $round->character2Id);
+        $flag = $changed ? ' *' : '';
+        echo "  round {$round->id} (tier {$round->tier}):"
+            . ' ' . formatEntrantLabel($slots[0])
+            . ' vs '
+            . formatEntrantLabel($slots[1])
+            . "{$flag}\n";
+    }
+    if (!$any) {
+        echo "  (none)\n";
+    }
+    echo "\n";
+}
+
+/**
+ * @param int $roundId
+ * @param int $character1Id
+ * @param int $character2Id
+ * @param int[] $excludeUserIds
+ * @return int|null
+ */
+function computeWinnerId($roundId, $character1Id, $character2Id, array $excludeUserIds) {
+    $character1Id = (int) $character1Id;
+    $character2Id = (int) $character2Id;
+
+    if ($character2Id === 1) {
+        return $character1Id ?: null;
+    }
+    if ($character1Id <= 0 || $character2Id <= 0) {
+        return null;
+    }
+
+    $votes1 = countCharacterVotes($roundId, $character1Id, $excludeUserIds);
+    $votes2 = countCharacterVotes($roundId, $character2Id, $excludeUserIds);
+
+    if ($votes1 > $votes2) {
+        return $character1Id;
+    }
+    if ($votes2 > $votes1) {
+        return $character2Id;
+    }
+
+    $seed1 = getCharacterSeed($character1Id);
+    $seed2 = getCharacterSeed($character2Id);
+    if ($seed1 < $seed2) {
+        return $character1Id;
+    }
+    return $character2Id;
+}
+
+/**
+ * @param int $character1Id
+ * @param int $character2Id
+ * @param int|null $winnerId
+ * @return int|null
+ */
+function computeLoserId($character1Id, $character2Id, $winnerId) {
+    if (!$winnerId || (int) $character2Id === 1) {
+        return null;
+    }
+    return (int) $winnerId === (int) $character1Id
+        ? (int) $character2Id
+        : (int) $character1Id;
+}
+
+/**
+ * @param int $characterId
+ * @return string
+ */
+function formatEntrantLabel($characterId) {
+    $characterId = (int) $characterId;
+    if ($characterId === 1) {
+        return 'bye';
+    }
+    $seed = getCharacterSeed($characterId);
+    if ($seed === PHP_INT_MAX) {
+        return 'seed ?';
+    }
+    return 'seed ' . $seed;
+}
+
+/**
+ * @param int $characterId
+ * @return int
+ */
+function getCharacterSeed($characterId) {
+    static $seeds = [];
+    $characterId = (int) $characterId;
+    if (!array_key_exists($characterId, $seeds)) {
+        $character = Api\Character::getById($characterId);
+        $seeds[$characterId] = $character && $character->seed !== null
+            ? (int) $character->seed
+            : PHP_INT_MAX;
+    }
+    return $seeds[$characterId];
+}
+
+/**
+ * @param int $roundId
+ * @param int $characterId
+ * @param int[] $excludeUserIds
+ * @return int
+ */
+function countCharacterVotes($roundId, $characterId, array $excludeUserIds) {
+    $characterId = (int) $characterId;
+    if ($characterId <= 0) {
+        return 0;
+    }
+
+    $params = [
+        ':roundId' => (int) $roundId,
+        ':characterId' => $characterId,
+    ];
+    $sql = 'SELECT COUNT(1) AS total FROM votes WHERE round_id = :roundId AND character_id = :characterId';
+    if (count($excludeUserIds) > 0) {
+        $sql .= ' AND user_id NOT IN (' . buildInPlaceholders($excludeUserIds, 'ex') . ')';
+        $params = array_merge($params, buildInParams($excludeUserIds, 'ex'));
+    }
+
+    return (int) fetchScalar($sql, $params);
+}
+
+/**
+ * @param string $sql
+ * @param array $params
+ * @return mixed
+ */
+function fetchScalar($sql, array $params) {
+    $result = Lib\Db::Query($sql, $params);
+    if (!$result || !$result->count) {
+        return 0;
+    }
+    $row = Lib\Db::Fetch($result);
+    if (isset($row->total)) {
+        return $row->total;
+    }
+    $values = array_values((array) $row);
+    return $values[0] ?? 0;
+}
+
+/**
+ * @param int[] $ids
+ * @param string $prefix
+ * @return string
+ */
+function buildInPlaceholders(array $ids, $prefix) {
+    $parts = [];
+    foreach (array_values($ids) as $index => $id) {
+        $parts[] = ':' . $prefix . $index;
+    }
+    return implode(',', $parts);
+}
+
+/**
+ * @param int[] $ids
+ * @param string $prefix
+ * @return array
+ */
+function buildInParams(array $ids, $prefix) {
+    $params = [];
+    foreach (array_values($ids) as $index => $id) {
+        $params[':' . $prefix . $index] = (int) $id;
+    }
+    return $params;
+}
+
+/**
+ * @param Api\Bracket $bracket
+ * @param Api\User[] $users
+ */
+function bustCaches(Api\Bracket $bracket, array $users) {
+    $bracket->getResults(true);
+    Api\Round::getCurrentRounds($bracket->id, true);
+    Lib\Cache::getInstance()->set('Api:Round:getVotingStates_' . $bracket->id, false, 1);
+
+    foreach ($users as $user) {
+        $bracket->getVotesForUser($user, true);
+    }
+
+    Api\Stats::getEntrantPerformanceStats($bracket, true);
+}


### PR DESCRIPTION
Had cursor help write a script that deletes all votes from a list of users for a specific contest. It also handles the case where the removed votes result in a different character winning a match. Note that in the case where the wrongly-advanced character already gained votes in the next tier match, I opted to not replace them with the rightful winner (the votes still got deleted so it looks a bit off but I think it's fine that it's obvious something went wrong with the contest).

Hopefully we won't be running this in a situation where we ever need to worry about that special case though.

I included the cursor plan to give more context into the script. It can probably be deleted before being merged. I'm not totally sure this script has to be merged to be run (probably does since it's containerized tho..)? Also I don't know if the docker compose command listed works for the prod environment.

Note I did not have time to thoroughly review or test this code (well still spent a good couple of hours). It did work perfectly fine in testing with single-user deletion at least, I didn't test multiple.