### PR TITLE
Authentication flow improvements

### DIFF
--- a/api/user.php
+++ b/api/user.php
@@ -24,6 +24,7 @@ namespace Api {
     public $csrfToken;
 
     const USER_CSRF_ENTROPY = 8;
+    const LOGIN_REJECT_CACHE_PREFIX = 'reddit_login_reject_';
 
     /**
      * Reddit registration date of the account.
@@ -80,8 +81,34 @@ namespace Api {
       $client = self::_createOAuth2();
 
       if ($client->getToken($code)) {
+        // get account data
         $data = $client->call('api/v1/me');
-        if ($data && isset($data->name) && (!isset($data->is_suspended) || $data->is_suspended === false)) {
+        if ($data && isset($data->name)) {
+          // check if already in reject cache
+          if (self::_hasLoginRejectCache($data->name)) {
+            return false;
+          }
+
+          // check if suspended
+          if (!empty($data->is_suspended)) {
+            self::_setLoginRejectCache($data->name, CACHE_LONG);
+            return false;
+          }
+
+          // check about data
+          $appClient = self::_createAppOAuth2();
+          $aboutData = $appClient->getUserAboutData($data->name);
+          $status = $aboutData ? (int) $aboutData->status : 0;
+          if ($status !== 200) {
+            if ($status === 404) {
+              self::_setLoginRejectCache($data->name, CACHE_LONG);
+            } else if ($status === 429) {
+              self::_setLoginRejectCache($data->name, CACHE_SHORT);
+            }
+            return false;
+          }
+
+          // get user from database
           $user = self::getByName($data->name);
           if (!$user) {
             $user = new User;
@@ -94,30 +121,43 @@ namespace Api {
             }
           } else {
 
-            // This is to update any records that were created before age was tracked
-            if (!$user->age) {
+            // Backfill legacy missing age, but make sure not to overwrite local ban
+            if ($user->age === null) {
               $user->age = (int) $data->created;
               $user->sync();
             }
           }
 
-          // Save the login attempt before verifying attempt count
-          self::_logLoginAttempt($user->id);
+          if ($user) {
+            // Save the login attempt before verifying attempt count
+            self::_logLoginAttempt($user->id);
 
-          // Now verify that the user isn't banned and hasn't tried logging in too much
-          if (
-            $user &&
-            $user->age > 0 &&
-            self::_verifyLoginAttempts($user->id)
-          ) {
-            $user->csrfToken = bin2hex(openssl_random_pseudo_bytes(self::USER_CSRF_ENTROPY));
-            Lib\Session::set('user', $user);
-            $retVal = true;
+            // Now verify that the user isn't banned and hasn't tried logging in too much
+            if (
+              $user->age > 0 &&
+              self::_verifyLoginAttempts($user->id)
+            ) {
+              $user->csrfToken = bin2hex(openssl_random_pseudo_bytes(self::USER_CSRF_ENTROPY));
+              Lib\Session::set('user', $user);
+              $retVal = true;
+            }
           }
         }
       }
 
       return $retVal;
+    }
+
+    private static function _loginRejectCacheKey($userName) {
+      return self::LOGIN_REJECT_CACHE_PREFIX . strtolower($userName);
+    }
+
+    private static function _hasLoginRejectCache($userName) {
+      return !!Lib\Cache::getInstance()->get(self::_loginRejectCacheKey($userName), true);
+    }
+
+    private static function _setLoginRejectCache($userName, $ttl) {
+      Lib\Cache::getInstance()->set(self::_loginRejectCacheKey($userName), true, $ttl);
     }
 
     private static function _createOAuth2(User $user = null) {
@@ -131,6 +171,10 @@ namespace Api {
       }
 
       return $retVal;
+    }
+
+    private static function _createAppOAuth2() {
+      return new Lib\AppRedditOAuth(REDDIT_TOKEN, REDDIT_SECRET, HTTP_UA);
     }
 
     /**

--- a/lib/appredditoauth.php
+++ b/lib/appredditoauth.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Lib {
+
+  class AppRedditOAuth extends RedditOAuth {
+
+    const APP_TOKEN_CACHE_KEY = 'reddit_app_access_token';
+    const APP_TOKEN_CACHE_MINIMUM_TTL = 30;
+    const TOKEN_EXPIRY_BUFFER_SECONDS = 60;
+
+    public function __construct($clientId, $clientSecret, $userAgent) {
+      parent::__construct($clientId, $clientSecret, $userAgent, null);
+    }
+
+    /**
+     * Get an application (user-less) access token, cached across requests.
+     */
+    public function getAccessToken() {
+      // if token is already set and valid, return it
+      if ($this->token && $this->_isTokenUsable($this->expiration)) {
+        return $this->token;
+      }
+
+      // now check cache for a valid token
+      $cache = Cache::getInstance();
+      $cached = $cache->get(self::APP_TOKEN_CACHE_KEY, true);
+      if (
+        $cached &&
+        is_object($cached) &&
+        !empty($cached->token) &&
+        !empty($cached->expiration) &&
+        $this->_isTokenUsable($cached->expiration)
+      ) {
+        $this->token = $cached->token;
+        $this->expiration = (int) $cached->expiration;
+        return $this->token;
+      }
+
+      // get new token
+      $response = $this->_post('access_token', [
+        'grant_type' => 'client_credentials'
+      ], false);
+
+      $this->_updateToken($response);
+      if (!$this->token) {
+        return false;
+      }
+
+      if ($this->expiration) {
+        // cache the token
+        $ttl = (int) $this->expiration - time() - self::TOKEN_EXPIRY_BUFFER_SECONDS;
+        if ($ttl < self::APP_TOKEN_CACHE_MINIMUM_TTL) {
+          $ttl = self::APP_TOKEN_CACHE_MINIMUM_TTL;
+        }
+
+        $cache->set(self::APP_TOKEN_CACHE_KEY, (object) [
+          'token' => $this->token,
+          'expiration' => $this->expiration
+        ], $ttl);
+      }
+
+      return $this->token;
+    }
+
+    /**
+     * Get user profile about data using an app access token.
+     * @return object|false Object with status and body, or false on failure to authorize
+     */
+    public function getUserAboutData($username) {
+      if (!$this->getAccessToken()) {
+        return false;
+      }
+
+      return $this->_getWithStatus('user/' . rawurlencode($username) . '/about');
+    }
+
+    private function _getWithStatus($endpoint) {
+      $c = $this->_createCurl($endpoint, true);
+      $response = curl_exec($c);
+      $status = (int) curl_getinfo($c, CURLINFO_HTTP_CODE);
+      $body = $response ? json_decode($response) : false;
+
+      return (object) [
+        'status' => $status,
+        'body' => $body
+      ];
+    }
+
+    protected function _verifyTokenFresh() {
+      return !!$this->getAccessToken();
+    }
+
+    private function _isTokenUsable($expiration) {
+      return $expiration && time() < ((int) $expiration - self::TOKEN_EXPIRY_BUFFER_SECONDS);
+    }
+  }
+
+}

--- a/lib/appredditoauth.php
+++ b/lib/appredditoauth.php
@@ -5,7 +5,6 @@ namespace Lib {
   class AppRedditOAuth extends RedditOAuth {
 
     const APP_TOKEN_CACHE_KEY = 'reddit_app_access_token';
-    const APP_TOKEN_CACHE_MINIMUM_TTL = 30;
     const TOKEN_EXPIRY_BUFFER_SECONDS = 60;
 
     public function __construct($clientId, $clientSecret, $userAgent) {
@@ -28,7 +27,6 @@ namespace Lib {
         $cached &&
         is_object($cached) &&
         !empty($cached->token) &&
-        !empty($cached->expiration) &&
         $this->_isTokenUsable($cached->expiration)
       ) {
         $this->token = $cached->token;
@@ -42,17 +40,15 @@ namespace Lib {
       ], false);
 
       $this->_updateToken($response);
-      if (!$this->token) {
+      if (!$this->token || !$this->expiration) {
+        $this->token = null;
+        $this->expiration = null;
         return false;
       }
 
-      if ($this->expiration) {
-        // cache the token
-        $ttl = (int) $this->expiration - time() - self::TOKEN_EXPIRY_BUFFER_SECONDS;
-        if ($ttl < self::APP_TOKEN_CACHE_MINIMUM_TTL) {
-          $ttl = self::APP_TOKEN_CACHE_MINIMUM_TTL;
-        }
-
+      // cache the token when enough time remains
+      $ttl = (int) $this->expiration - time() - self::TOKEN_EXPIRY_BUFFER_SECONDS;
+      if ($ttl > 0) {
         $cache->set(self::APP_TOKEN_CACHE_KEY, (object) [
           'token' => $this->token,
           'expiration' => $this->expiration

--- a/lib/redditoauth.php
+++ b/lib/redditoauth.php
@@ -7,13 +7,14 @@ namespace Lib {
     const REDDIT_API_URL = 'https://www.reddit.com/api/v1';
     const REDDIT_OAUTH_URL = 'https://oauth.reddit.com';
 
-    private $clientId = null;
-    private $clientSecret = null;
-    private $clientUserAgent = null;
-    private $handlerUrl = null;
-    private $token = null;
-    private $refreshToken = null;
-    private $expiration = null;
+    protected $clientId = null;
+    protected $clientSecret = null;
+    protected $clientUserAgent = null;
+    protected $handlerUrl = null;
+
+    protected $token = null;
+    protected $refreshToken = null;
+    protected $expiration = null;
 
     public function __construct($clientId, $clientSecret, $userAgent, $handlerUrl) {
       $this->clientId = $clientId;
@@ -97,7 +98,7 @@ namespace Lib {
       return $retVal;
     }
 
-    private function _updateToken($response) {
+    protected function _updateToken($response) {
       if ($response && isset($response->access_token)) {
         $this->token = $response->access_token;
         if (isset($response->refresh_token)) {
@@ -105,9 +106,8 @@ namespace Lib {
         }
 
         if (isset($response->expires_in)) {
-          $this->expiration = time() + $response->expires_in;
+          $this->expiration = time() + (int) $response->expires_in;
         }
-        $retVal = $this->token;
       } else {
         $this->token = null;
       }
@@ -117,7 +117,7 @@ namespace Lib {
      * Verifies that the current token is still fresh. If not,
      * refreshs if possible
      */
-    private function _verifyTokenFresh() {
+    protected function _verifyTokenFresh() {
       $retVal = time() < $this->expiration;
 
       if (!$retVal && $this->refreshToken) {
@@ -133,7 +133,7 @@ namespace Lib {
       return $retVal;
     }
 
-    private function _createCurl($endpoint, $isOauth = true) {
+    protected function _createCurl($endpoint, $isOauth = true) {
       $apiUrl = $isOauth ? self::REDDIT_OAUTH_URL : self::REDDIT_API_URL;
 
       $retVal = curl_init($apiUrl . '/' . $endpoint);
@@ -161,7 +161,7 @@ namespace Lib {
     /**
      * Makes an OAuthenticated POST request
      */
-    private function _post($endpoint, array $params, $isOauth = true) {
+    protected function _post($endpoint, array $params, $isOauth = true) {
       $c = $this->_createCurl($endpoint, $isOauth);
       curl_setopt($c, CURLOPT_POST, true);
       curl_setopt($c, CURLOPT_POSTFIELDS, $params);


### PR DESCRIPTION
- add `user/{username}/about` check to verify account status
  - required creating a new `AppRedditOAuth` class that extends `RedditOAuth` in order to get app access token (the design for this is not the greatest but I wanted as little code change as possible since it's difficult to test)
  - app access token is cached until expiration
 - fixed local user ban status being overwritten during login
 - added a login reject cache to reduce spam from known bad accounts

Note: we should probably add in better rate limit handling someday... though it's probably not a real concern unless we start seeing a lot more traffic